### PR TITLE
[TASK] Improve TCA configuration

### DIFF
--- a/Classes/Controller/MediaController.php
+++ b/Classes/Controller/MediaController.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use RuntimeException;
 
 /**
  * Controller for rendering media.
@@ -105,7 +106,7 @@ class MediaController extends ActionController
             return (new ForwardResponse('audio'))->withArguments(['audio' => $media->getUid()]);
         }
 
-        throw new \RuntimeException('An invalid media type is used.');
+        throw new RuntimeException('An invalid media type is used.');
     }
 
     /**

--- a/Classes/Controller/MediaController.php
+++ b/Classes/Controller/MediaController.php
@@ -106,7 +106,7 @@ class MediaController extends ActionController
             return (new ForwardResponse('audio'))->withArguments(['audio' => $media->getUid()]);
         }
 
-        throw new RuntimeException('An invalid media type is used.');
+        throw new RuntimeException('An invalid media type is used.'); // @codeCoverageIgnore
     }
 
     /**

--- a/Classes/Controller/MediaController.php
+++ b/Classes/Controller/MediaController.php
@@ -95,7 +95,7 @@ class MediaController extends ActionController
         // We update the last changed register when a media record has changed because
         // the content element will not get this information if no properties in the
         // content element are changed.
-        $contentObject = $contentObject = $this->getCurrentContentObject();
+        $contentObject = $this->getCurrentContentObject();
         $contentObject->lastChanged($media->getTstamp());
 
         if ($mediaType->equals(MediaType::VIDEO)) {

--- a/Classes/Domain/Model/Enumeration/MediaType.php
+++ b/Classes/Domain/Model/Enumeration/MediaType.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Core\Type\Enumeration;
 
 /**
  * Enumeration of allowed media types.
+ *
+ * @codeCoverageIgnore No code to test.
  */
 class MediaType extends Enumeration
 {

--- a/Classes/Domain/Repository/MediaRepository.php
+++ b/Classes/Domain/Repository/MediaRepository.php
@@ -18,6 +18,7 @@ use Sto\Html5mediakit\Domain\Model\Media;
 use Sto\Html5mediakit\Exception\MediaMissingException;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
+use InvalidArgumentException;
 
 /**
  * Repository for retrieving media files from the database.
@@ -76,10 +77,10 @@ class MediaRepository extends Repository
     private function validateParentRecordData($data): void
     {
         if (empty($data['parent_table'])) {
-            throw new \InvalidArgumentException('parent_table field is missing in content data.');
+            throw new InvalidArgumentException('parent_table field is missing in content data.');
         }
         if (empty($data['parent_record'])) {
-            throw new \InvalidArgumentException('parent_record field is missing in content data.');
+            throw new InvalidArgumentException('parent_record field is missing in content data.');
         }
     }
 }

--- a/Classes/Exception/MediaException.php
+++ b/Classes/Exception/MediaException.php
@@ -18,6 +18,8 @@ use RuntimeException;
 
 /**
  * Generic media related Exception. Translations should be available for the Exception code.
+ *
+ * @codeCoverageIgnore No code to test.
  */
 class MediaException extends RuntimeException
 {

--- a/Classes/Exception/MediaException.php
+++ b/Classes/Exception/MediaException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sto\Html5mediakit\Exception;
 
+use RuntimeException;
+
 /*                                                                        *
  * This script belongs to the TYPO3 Extension "html5mediakit".            *
  *                                                                        *
@@ -17,6 +19,6 @@ namespace Sto\Html5mediakit\Exception;
 /**
  * Generic media related Exception. Translations should be available for the Exception code.
  */
-class MediaException extends \RuntimeException
+class MediaException extends RuntimeException
 {
 }

--- a/Classes/Exception/MediaMissingException.php
+++ b/Classes/Exception/MediaMissingException.php
@@ -21,7 +21,7 @@ use Exception;
  */
 class MediaMissingException extends MediaException
 {
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $code = 0, Exception $previous = null)
     {
         if ($message === '') {
             $message = 'No media exists in the current content element.';

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -6,13 +6,6 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 $lllPrefix = 'LLL:EXT:html5mediakit/Resources/Private/Language/locallang_db:sys_file_reference.';
 
-$displayCondition = [
-    'AND' => [
-        'FIELD:tablenames:=:tx_html5mediakit_domain_model_media',
-        'FIELD:fieldname:=:tracks',
-    ],
-];
-
 $additionalColumns = [
     'tx_html5mediakit_track_kind' => [
         'label' => $lllPrefix . 'tx_html5mediakit_track_kind',
@@ -43,7 +36,6 @@ $additionalColumns = [
             ],
             'default' => 'subtitles',
         ],
-        'displayCond' => $displayCondition,
     ],
     'tx_html5mediakit_track_label' => [
         'label' => $lllPrefix . 'tx_html5mediakit_track_label',
@@ -53,7 +45,6 @@ $additionalColumns = [
             'eval' => 'trim',
             'size' => 10,
         ],
-        'displayCond' => $displayCondition,
     ],
     'tx_html5mediakit_track_srclang' => [
         'label' => $lllPrefix . 'tx_html5mediakit_track_srclang',
@@ -65,18 +56,10 @@ $additionalColumns = [
             'max' => 2,
             'size' => 10,
         ],
-        'displayCond' => $displayCondition,
     ],
 ];
 
 ExtensionManagementUtility::addTCAcolumns(
     'sys_file_reference',
     $additionalColumns
-);
-
-ExtensionManagementUtility::addToAllTCAtypes(
-    'sys_file_reference',
-    'tx_html5mediakit_track_kind, tx_html5mediakit_track_label, tx_html5mediakit_track_srclang',
-    '',
-    'after:title',
 );

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -43,6 +43,7 @@ $GLOBALS['TCA']['tt_content']['types']['html5mediakit_mediarenderer']['showitem'
     --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
         --palette--;;general,
         --palette--;;headers,
+    --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.media,
         tx_html5mediakit_media,
     --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
         --palette--;;frames,

--- a/Configuration/TCA/tx_html5mediakit_domain_model_media.php
+++ b/Configuration/TCA/tx_html5mediakit_domain_model_media.php
@@ -10,39 +10,57 @@ $languagePrefixColumn = $languagePrefix . 'tx_html5mediakit_domain_model_media.'
 $languagePrefixCsh = 'LLL:EXT:html5mediakit/Resources/Private/Language/locallang_csh_media.xlf:';
 $lllAddImageFileReference = 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference';
 
-$buildFileFieldConfig = function (array $allowedFileTypes) use ($languagePrefix) {
-    return [
+$buildFileFieldConfig = function (
+    array $allowedFileTypes,
+    int $maxitems = 1,
+    string $showitem = ''
+) use (
+    $languagePrefix
+) {
+    $showitem .= ',--palette--;;filePalette';
+    $showitem = ltrim($showitem, ',');
+    $allowsMultipleFiles = $maxitems === 0 || $maxitems > 1;
+
+    $config = [
         'type' => 'file',
         'allowed' => $allowedFileTypes,
+        'behaviour' => ['allowLanguageSynchronization' => true],
         'appearance' => [
+            'showPossibleLocalizationRecords' => $allowsMultipleFiles,
             'createNewRelationLinkTitle' => $languagePrefix . 'choose_file',
-            'useSortable' => false,
+            'useSortable' => $allowsMultipleFiles,
             'headerThumbnail' => [
                 'field' => '',
                 'width' => '0',
                 'height' => '0',
             ],
             'enabledControls' => [
-                'info' => false,
-                'new' => false,
-                'dragdrop' => false,
-                'sort' => false,
-                'hide' => false,
+                'info' => true,
+                'new' => $allowsMultipleFiles,
+                'dragdrop' => $allowsMultipleFiles,
+                'sort' => $allowsMultipleFiles,
+                'hide' => $allowsMultipleFiles,
                 'delete' => true,
-                'localize' => false,
+                'localize' => $allowsMultipleFiles,
             ],
         ],
         'overrideChildTca' => [
             'types' => [
-                '0' => ['showitem' => '--palette--;;filePalette'],
-                AbstractFile::FILETYPE_AUDIO => ['showitem' => '--palette--;;filePalette'],
-                AbstractFile::FILETYPE_VIDEO => ['showitem' => '--palette--;;filePalette'],
-                AbstractFile::FILETYPE_APPLICATION => ['showitem' => '--palette--;;filePalette'],
+                AbstractFile::FILETYPE_UNKNOWN => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_AUDIO => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_VIDEO => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_APPLICATION => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_TEXT => ['showitem' => $showitem],
             ],
         ],
-        'maxitems' => 1,
         'security' => ['ignorePageTypeRestriction' => true],
     ];
+
+    if ($maxitems > 0) {
+        $config['maxitems'] = $maxitems;
+    }
+
+    return $config;
 };
 
 return [
@@ -90,10 +108,11 @@ return [
         'tracks' => [
             'label' => $languagePrefixColumn . 'tracks',
             'description' => $languagePrefixCsh . 'tracks.description',
-            'config' => [
-                'type' => 'file',
-                'allowed' => 'vtt',
-            ],
+            'config' => $buildFileFieldConfig(
+                ['vtt'],
+                0,
+                'tx_html5mediakit_track_kind, tx_html5mediakit_track_label, tx_html5mediakit_track_srclang',
+            ),
         ],
         'caption' => [
             'label' => $languagePrefixColumn . 'caption',
@@ -193,27 +212,36 @@ return [
         '0' => ['showitem' => 'type,--palette--;;hiddenFields'],
         'video' => [
             'showitem' => '
-                type, h264, web_m, ogv, poster,
-                --palette--;' . $languagePrefixColumn . 'palette.metadata;metadata,
-                --palette--;;hiddenFields
+                --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.media,
+                    type, h264, web_m, ogv, poster,
+                    --palette--;;hiddenFields,
+                --div--;' . $languagePrefixColumn . 'tracks,
+                    tracks,
+                --div--;' . $languagePrefixColumn . 'palette.metadata;metadata,
+                    caption, description,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language,
             ',
         ],
         'audio' => [
             'showitem' => '
-                type, mp3, ogg,
-                --palette--;' . $languagePrefixColumn . 'palette.metadata;metadata,
-                --palette--;;hiddenFields
+                --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.media,
+                    type, mp3, ogg,
+                    --palette--;;hiddenFields,
+                --div--;' . $languagePrefixColumn . 'tracks,
+                    tracks,
+                --div--;' . $languagePrefixColumn . 'palette.metadata;metadata,
+                    caption, description,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language,
             ',
         ],
     ],
     'palettes' => [
-        'metadata' => [
-            'showitem' => 'tracks, --linebreak--, caption, --linebreak--, description',
-            'canNotCollapse' => 1,
-        ],
-        'hiddenFields' => [
-            'showitem' => 'sys_language_uid, l10n_parent',
-            'isHiddenPalette' => true,
+        'language' => [
+            'showitem' => '
+                sys_language_uid, l10n_parent
+            ',
         ],
     ],
 ];

--- a/Configuration/TCA/tx_html5mediakit_domain_model_media.php
+++ b/Configuration/TCA/tx_html5mediakit_domain_model_media.php
@@ -11,9 +11,10 @@ $languagePrefixCsh = 'LLL:EXT:html5mediakit/Resources/Private/Language/locallang
 $lllAddImageFileReference = 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference';
 
 $buildFileFieldConfig = function (
-    array $allowedFileTypes,
+    string|array $allowedFileTypes,
     int $maxitems = 1,
-    string $showitem = ''
+    string $showitem = '',
+    string $createNewRelationLinkTitle = '',
 ) use (
     $languagePrefix
 ) {
@@ -21,13 +22,16 @@ $buildFileFieldConfig = function (
     $showitem = ltrim($showitem, ',');
     $allowsMultipleFiles = $maxitems === 0 || $maxitems > 1;
 
+    if ($createNewRelationLinkTitle === '') {
+        $createNewRelationLinkTitle = $languagePrefix . 'choose_file';
+    }
+
     $config = [
         'type' => 'file',
         'allowed' => $allowedFileTypes,
-        'behaviour' => ['allowLanguageSynchronization' => true],
         'appearance' => [
-            'showPossibleLocalizationRecords' => $allowsMultipleFiles,
-            'createNewRelationLinkTitle' => $languagePrefix . 'choose_file',
+            'showPossibleLocalizationRecords' => true,
+            'createNewRelationLinkTitle' => $createNewRelationLinkTitle,
             'useSortable' => $allowsMultipleFiles,
             'headerThumbnail' => [
                 'field' => '',
@@ -41,16 +45,17 @@ $buildFileFieldConfig = function (
                 'sort' => $allowsMultipleFiles,
                 'hide' => $allowsMultipleFiles,
                 'delete' => true,
-                'localize' => $allowsMultipleFiles,
+                'localize' => true,
             ],
         ],
         'overrideChildTca' => [
             'types' => [
-                AbstractFile::FILETYPE_UNKNOWN => ['showitem' => $showitem],
-                AbstractFile::FILETYPE_AUDIO => ['showitem' => $showitem],
-                AbstractFile::FILETYPE_VIDEO => ['showitem' => $showitem],
                 AbstractFile::FILETYPE_APPLICATION => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_AUDIO => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_IMAGE => ['showitem' => $showitem],
                 AbstractFile::FILETYPE_TEXT => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_UNKNOWN => ['showitem' => $showitem],
+                AbstractFile::FILETYPE_VIDEO => ['showitem' => $showitem],
             ],
         ],
         'security' => ['ignorePageTypeRestriction' => true],
@@ -177,19 +182,10 @@ return [
         ],
         'poster' => [
             'label' => $languagePrefixColumn . 'poster',
-            'config' => [
-                'type' => 'file',
-                'allowed' => 'common-image-types',
-                'appearance' => ['createNewRelationLinkTitle' => $lllAddImageFileReference],
-                'maxitems' => 1,
-                'behaviour' => ['allowLanguageSynchronization' => true],
-                'overrideChildTca' => [
-                    'types' => [
-                        '0' => ['showitem' => '--palette--;;filePalette'],
-                        AbstractFile::FILETYPE_IMAGE => ['showitem' => '--palette--;;filePalette'],
-                    ],
-                ],
-            ],
+            'config' => $buildFileFieldConfig(
+                allowedFileTypes: 'common-image-types',
+                createNewRelationLinkTitle: $lllAddImageFileReference
+            ),
         ],
         'sys_language_uid' => [
             'exclude' => true,

--- a/Configuration/TCA/tx_html5mediakit_domain_model_media.php
+++ b/Configuration/TCA/tx_html5mediakit_domain_model_media.php
@@ -34,11 +34,6 @@ $buildFileFieldConfig = function (
             'showAllLocalizationLink' => $allowsMultipleFiles,
             'createNewRelationLinkTitle' => $createNewRelationLinkTitle,
             'useSortable' => $allowsMultipleFiles,
-            'headerThumbnail' => [
-                'field' => '',
-                'width' => '0',
-                'height' => '0',
-            ],
             'enabledControls' => [
                 'info' => true,
                 'new' => $allowsMultipleFiles,

--- a/Configuration/TCA/tx_html5mediakit_domain_model_media.php
+++ b/Configuration/TCA/tx_html5mediakit_domain_model_media.php
@@ -31,6 +31,7 @@ $buildFileFieldConfig = function (
         'allowed' => $allowedFileTypes,
         'appearance' => [
             'showPossibleLocalizationRecords' => true,
+            'showAllLocalizationLink' => $allowsMultipleFiles,
             'createNewRelationLinkTitle' => $createNewRelationLinkTitle,
             'useSortable' => $allowsMultipleFiles,
             'headerThumbnail' => [

--- a/Tests/Acceptance/Backend/ContentCreationCest.php
+++ b/Tests/Acceptance/Backend/ContentCreationCest.php
@@ -37,9 +37,15 @@ class ContentCreationCest
         $I->waitForElement($headerInputSelector);
         $I->fillField($headerInputSelector, 'Testheader');
 
+        // Switch to tab "Media"
+        $I->click('.typo3-TCEforms > ' . $this->buildTabSelector(2));
+
         $I->click('Create new');
 
         $I->waitForElement('div[data-title="Media file"] select[name$="[type]"]');
+
+        // Tab "Meta data"
+        $I->click('div[data-foreign-table="tx_html5mediakit_domain_model_media"] ' . $this->buildTabSelector(3));
 
         $I->fillField('div[data-title="Media file"] input[data-formengine-input-name$="[caption]"]', 'The caption');
 
@@ -51,8 +57,19 @@ class ContentCreationCest
 
         $I->seeInField($headerInputSelector, 'Testheader');
 
+        // Switch to tab "Media"
+        $I->click('.typo3-TCEforms > ' . $this->buildTabSelector(2));
+
         $I->click('#data-1-tt_content-1-tx_html5mediakit_media-tx_html5mediakit_domain_model_media-1_label');
         $I->waitForElement('div[data-title="Media file"] select[name$="[type]"]');
         $I->seeInField('div[data-title="Media file"] input[data-formengine-input-name$="[caption]"]', 'The caption');
+    }
+
+    private function buildTabSelector(int $tabNumber): string
+    {
+        return sprintf(
+            'div[role="tabpanel"] > ul.nav-tabs > li.t3js-tabmenu-item:nth-child(%d) > a',
+            $tabNumber
+        );
     }
 }

--- a/Tests/Acceptance/Support/Extension/BackendHtml5mediakitEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendHtml5mediakitEnvironment.php
@@ -6,6 +6,7 @@ namespace Sto\Html5mediakit\Tests\Acceptance\Support\Extension;
 
 use Codeception\Event\SuiteEvent;
 use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
+use RuntimeException;
 
 class BackendHtml5mediakitEnvironment extends BackendEnvironment
 {
@@ -38,7 +39,7 @@ class BackendHtml5mediakitEnvironment extends BackendEnvironment
         $typo3RootPath = (string)getenv('TYPO3_PATH_ROOT');
 
         if ($typo3RootPath === '') {
-            throw new \RuntimeException('TYPO3_PATH_ROOT environment variable is not set');
+            throw new RuntimeException('TYPO3_PATH_ROOT environment variable is not set');
         }
 
         $putenvCode = PHP_EOL

--- a/Tests/Functional/Controller/MediaController/VideoTest.php
+++ b/Tests/Functional/Controller/MediaController/VideoTest.php
@@ -4,8 +4,27 @@ declare(strict_types=1);
 
 namespace Sto\Html5mediakit\Tests\Functional\Controller\MediaController;
 
+use Symfony\Component\DomCrawler\Crawler;
+
 class VideoTest extends AbstractMediaControllerTestCase
 {
+    private array $expectedTracks = [
+        [
+            'src' => '/tracks/subtitles-en.vtt',
+            'kind' => 'subtitles',
+            'srclang' => 'en',
+            'label' => 'English',
+            'default' => true,
+        ],
+        [
+            'src' => '/tracks/subtitles-de.vtt',
+            'kind' => 'subtitles',
+            'srclang' => 'de',
+            'label' => 'German',
+            'default' => false,
+        ],
+    ];
+
     private array $formats = [
         'webm' => 'webm',
         'mp4' => 'mp4',
@@ -16,28 +35,75 @@ class VideoTest extends AbstractMediaControllerTestCase
     {
         $responseBody = $this->loadFixturesAndGetResponseBody('media/video');
 
-        $this->assertResponseContainsSources($responseBody);
-        $this->assertResponseContainsFallbackLinks($responseBody);
-        self::assertStringContainsString('Testcaption', $responseBody);
-        self::assertStringContainsString('Testdescription', $responseBody);
-        self::assertStringContainsString('poster="/video/poster.png"', $responseBody);
+        $crawler = new Crawler($responseBody);
+
+        $videoContent = $this->getSingleElement($crawler, 'div.tx-html5mediakit-media-container');
+
+        $videoElement = $this->getSingleElement($videoContent, 'video');
+
+        self::assertSame('/video/poster.png', $videoElement->attr('poster'));
+
+        $this->assertVideoContainsSources($videoElement);
+
+        $fallbackText = $this->getSingleElement($videoContent, '.tx-html5mediakit-video-fallbacktext');
+        $this->assertFallbacktextContainsFallbackLinks($fallbackText);
+
+        $this->assertValidMetaData($this->getSingleElement($videoContent, '.tx-html5mediakit-media-metadata'));
+
+        $this->assertVideoContainsTracks($videoElement);
     }
 
-    private function assertResponseContainsFallbackLinks(string $responseBody): void
+    private function assertFallbacktextContainsFallbackLinks(Crawler $fallbackText): void
     {
         foreach ($this->formats as $extension) {
             /** @noinspection HtmlUnknownTarget */
-            $expectedSource = sprintf('<a href="/video/media.%s">media.%1$s</a>', $extension);
-            self::assertStringContainsString($expectedSource, $responseBody);
+            $fallbackLink = $fallbackText->filter(sprintf('a[href="/video/media.%s"]', $extension));
+            self::assertCount(1, $fallbackLink);
+            self::assertSame('media.' . $extension, $fallbackLink->text());
         }
     }
 
-    private function assertResponseContainsSources(string $responseBody): void
+    private function assertValidMetaData(Crawler $metaDataElement): void
+    {
+        self::assertStringContainsString(
+            'Testcaption',
+            $this->getSingleElement($metaDataElement, '.tx-html5mediakit-media-caption')->text()
+        );
+
+        self::assertStringContainsString(
+            'Testdescription',
+            $this->getSingleElement($metaDataElement, '.tx-html5mediakit-media-description')->text()
+        );
+    }
+
+    private function assertVideoContainsSources(Crawler $videoElement): void
     {
         foreach ($this->formats as $mimeType => $extension) {
-            /** @noinspection HtmlUnknownTarget */
-            $expectedSource = sprintf('<source src="/video/media.%s" type="video/%s"/>', $extension, $mimeType);
-            self::assertStringContainsString($expectedSource, $responseBody);
+            $source = $videoElement->filter(sprintf('source[type="video/%s"]', $mimeType));
+            self::assertCount(1, $source);
+            self::assertSame('/video/media.' . $extension, $source->attr('src'));
         }
+    }
+
+    private function assertVideoContainsTracks(Crawler $videoElement): void
+    {
+        foreach ($this->expectedTracks as $expectedTrack) {
+            $track = $this->getSingleElement($videoElement, sprintf('track[src="%s"]', $expectedTrack['src']));
+            self::assertSame($expectedTrack['kind'], $track->attr('kind'));
+            self::assertSame($expectedTrack['srclang'], $track->attr('srclang'));
+            self::assertSame($expectedTrack['label'], $track->attr('label'));
+
+            $expectedDefault = $expectedTrack['default'] ? '' : null;
+            self::assertSame($expectedDefault, $track->attr('default'));
+        }
+    }
+
+    private function getSingleElement(Crawler $crawler, string $selector): Crawler
+    {
+        $elements = $crawler->filter($selector);
+
+        self::assertCount(1, $elements, 'Expected exactly one element matching selector "' . $selector . '"');
+
+        return $elements->first();
     }
 }

--- a/Tests/Functional/Fixtures/Database/common.csv
+++ b/Tests/Functional/Fixtures/Database/common.csv
@@ -6,3 +6,5 @@ sys_file,,,,,,
 ,4,0,0,video/media.ogv,media.ogv,4
 ,5,0,0,video/media.webm,media.webm,4
 ,6,0,0,video/poster.png,poster.png,2
+,7,0,0,tracks/subtitles-en.vtt,subtitles-en.vtt,1
+,8,0,0,tracks/subtitles-de.vtt,subtitles-de.vtt,1

--- a/Tests/Functional/Fixtures/Database/media/video.csv
+++ b/Tests/Functional/Fixtures/Database/media/video.csv
@@ -7,9 +7,11 @@ tt_content,,,,,,,
 tx_html5mediakit_domain_model_media,,,,,,,,,,,
 ,uid,pid,content_element,type,caption,description,h264,ogv,web_m,poster,deleted
 ,1,1,1,video,Testcaption,Testdescription,1,1,1,1,0
-sys_file_reference,,,,,,,,
-,uid,pid,uid_local,uid_foreign,tablenames,fieldname,l10n_diffsource
-,1,0,3,1,tx_html5mediakit_domain_model_media,h264,
-,2,0,4,1,tx_html5mediakit_domain_model_media,ogv,
-,3,0,5,1,tx_html5mediakit_domain_model_media,web_m,
-,4,0,6,1,tx_html5mediakit_domain_model_media,poster,
+sys_file_reference,,,,,,,,,,
+,uid,pid,uid_local,uid_foreign,tablenames,fieldname,tx_html5mediakit_track_kind,tx_html5mediakit_track_label,tx_html5mediakit_track_srclang
+,1,0,3,1,tx_html5mediakit_domain_model_media,h264,,,
+,2,0,4,1,tx_html5mediakit_domain_model_media,ogv,,,
+,3,0,5,1,tx_html5mediakit_domain_model_media,web_m,,,
+,4,0,6,1,tx_html5mediakit_domain_model_media,poster,,,
+,5,0,7,1,tx_html5mediakit_domain_model_media,tracks,subtitles,English,en
+,6,0,8,1,tx_html5mediakit_domain_model_media,tracks,subtitles,German,de

--- a/Tests/Unit/Domain/Model/MediaTest.php
+++ b/Tests/Unit/Domain/Model/MediaTest.php
@@ -15,19 +15,25 @@ namespace Sto\Html5mediakit\Tests\Unit\Domain\Model;
  *                                                                        */
 
 use PHPUnit\Framework\TestCase;
+use Sto\Html5mediakit\Domain\Model\Enumeration\MediaType;
 use Sto\Html5mediakit\Domain\Model\Media;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class MediaTest extends TestCase
 {
-    /**
-     * @var Media
-     */
-    protected $media;
+    protected Media $media;
 
     protected function setUp(): void
     {
         $this->media = GeneralUtility::makeInstance(Media::class);
+    }
+
+    public function testGetContentElementReturnsExpectedValue(): void
+    {
+        $this->media->setContentElement(343);
+
+        self::assertSame(343, $this->media->getContentElement());
     }
 
     public function testGetHasMetadataReturnsFalseIfNoTeaserOrDescriptionPresent(): void
@@ -49,5 +55,44 @@ class MediaTest extends TestCase
         $this->media->setCaption('');
         $this->media->setDescription('not empty');
         self::assertTrue($this->media->getHasMetadata());
+    }
+
+    public function testGetParentRecordReturnsExpectedValue(): void
+    {
+        $this->media->setParentRecord(6176);
+
+        self::assertSame(6176, $this->media->getParentRecord());
+    }
+
+    public function testGetParentTableReturnsExpectedValue(): void
+    {
+        $this->media->setParentTable('the_table');
+
+        self::assertSame('the_table', $this->media->getParentTable());
+    }
+
+    public function testGetTracksReturnsExpectedValue(): void
+    {
+        $theStorage = new ObjectStorage();
+
+        $this->media->setTracks($theStorage);
+
+        self::assertSame($theStorage, $this->media->getTracks());
+    }
+
+    public function testGetTstampReturnsExpectedValue(): void
+    {
+        $this->media->setTstamp(388384);
+
+        self::assertSame(388384, $this->media->getTstamp());
+    }
+
+    public function testGetTypeReturnsExpectedValue(): void
+    {
+        $theType = new MediaType(MediaType::AUDIO);
+
+        $this->media->setType($theType);
+
+        self::assertSame($theType, $this->media->getType());
     }
 }

--- a/Tests/Unit/Exception/MediaMissingExceptionTest.php
+++ b/Tests/Unit/Exception/MediaMissingExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sto\Html5mediakit\Tests\Unit\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Sto\Html5mediakit\Exception\MediaMissingException;
+
+class MediaMissingExceptionTest extends TestCase
+{
+    public function testConstructorDoesNotOverrideProvidedValues(): void
+    {
+        $exception = new MediaMissingException('Custom message', 3838);
+
+        self::assertSame('Custom message', $exception->getMessage());
+        self::assertSame(3838, $exception->getCode());
+    }
+
+    public function testConstructorSetsExpectedDefaultValues(): void
+    {
+        $exception = new MediaMissingException();
+
+        self::assertSame('No media exists in the current content element.', $exception->getMessage());
+        self::assertSame(1483385454, $exception->getCode());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"friendsofphp/php-cs-fixer": "^3.14",
 		"michielroos/typo3scan": "^1.7",
 		"squizlabs/php_codesniffer": "^3.7",
+		"symfony/dom-crawler": "^6.3",
 		"typo3/cms-fluid-styled-content": "*"
 	},
 	"replace": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"typo3/cms-frontend": "*"
 	},
 	"require-dev": {
-		"de-swebhosting/php-codestyle": "^4.0",
+		"de-swebhosting/php-codestyle": "^5.0",
 		"de-swebhosting/typo3-extension-buildtools": "dev-TYPO3_12",
 		"ergebnis/composer-normalize": "^2.28",
 		"friendsofphp/php-cs-fixer": "^3.14",


### PR DESCRIPTION
Move media to seperate tab in tt_content form (make it more consistent with default media).

Improve showitem config for sys_file_reference: make display condition obsolete by only showing the fields via overrideChildTca in the tracks field config.

Improve showitem config for media: split fields into four tabs, make language fields visible for easier debugging and error correction.

Disable allowLanguageSynchronization behavior for all file fields and show localize buttons.

