### PR TITLE
[!!!][BUGFIX] Increase size of relation fields 12.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 ---
 on:
   push:
+    branches:
+      - main
+      - develop
+      - 12.x
   pull_request:
   workflow_dispatch:
 

--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
 
 if (PHP_SAPI !== 'cli') {
     exit('This script supports command line usage only. Please check your command.');
@@ -12,11 +13,11 @@ $rules = include __DIR__ . '/../../.Build/vendor/de-swebhosting/php-codestyle/Ph
 
 return (new Config())
     ->setFinder(
-        (new PhpCsFixer\Finder())
+        (new Finder())
             ->ignoreVCSIgnored(true)
             ->in(realpath(__DIR__ . '/../../'))
             ->exclude(['.Build'])
-            ->notName(['ext_emconf.php', 'ext_localconf.php', 'ext_tables.php'])
+            ->notName(['ext_emconf.php', 'ext_localconf.php', 'ext_tables.php']),
     )
     ->setRiskyAllowed(true)
     ->setRules($rules);

--- a/Classes/Controller/MediaController.php
+++ b/Classes/Controller/MediaController.php
@@ -15,6 +15,7 @@ namespace Sto\Html5mediakit\Controller;
  *                                                                        */
 
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Sto\Html5mediakit\Domain\Model\Audio;
 use Sto\Html5mediakit\Domain\Model\Enumeration\MediaType;
 use Sto\Html5mediakit\Domain\Model\Media;
@@ -25,7 +26,6 @@ use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use RuntimeException;
 
 /**
  * Controller for rendering media.

--- a/Classes/Domain/Model/Audio.php
+++ b/Classes/Domain/Model/Audio.php
@@ -24,14 +24,14 @@ class Audio extends Media
     /**
      * Reference to the MP3 version of the audio.
      *
-     * @var \TYPO3\CMS\Extbase\Domain\Model\FileReference
+     * @var FileReference
      */
     protected $mp3;
 
     /**
      * Reference to the OGA/OGG Vorbis version of the audio.
      *
-     * @var \TYPO3\CMS\Extbase\Domain\Model\FileReference
+     * @var FileReference
      */
     protected $ogg;
 

--- a/Classes/Domain/Model/Media.php
+++ b/Classes/Domain/Model/Media.php
@@ -15,8 +15,8 @@ namespace Sto\Html5mediakit\Domain\Model;
  *                                                                        */
 
 use Sto\Html5mediakit\Domain\Model\Enumeration\MediaType;
-use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
@@ -71,7 +71,7 @@ class Media extends AbstractEntity
     /**
      * The type of the media element (can be audio or video).
      *
-     * @var \Sto\Html5mediakit\Domain\Model\Enumeration\MediaType
+     * @var MediaType
      */
     protected $type;
 

--- a/Classes/Domain/Repository/MediaRepository.php
+++ b/Classes/Domain/Repository/MediaRepository.php
@@ -14,11 +14,11 @@ namespace Sto\Html5mediakit\Domain\Repository;
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
 
+use InvalidArgumentException;
 use Sto\Html5mediakit\Domain\Model\Media;
 use Sto\Html5mediakit\Exception\MediaMissingException;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
-use InvalidArgumentException;
 
 /**
  * Repository for retrieving media files from the database.

--- a/Classes/Exception/MediaMissingException.php
+++ b/Classes/Exception/MediaMissingException.php
@@ -21,7 +21,7 @@ use Exception;
  */
 class MediaMissingException extends MediaException
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         if ($message === '') {
             $message = 'No media exists in the current content element.';

--- a/Classes/ViewHelpers/VideoViewHelper.php
+++ b/Classes/ViewHelpers/VideoViewHelper.php
@@ -20,14 +20,14 @@ class VideoViewHelper extends AbstractTagBasedViewHelper
             'string',
             'Specifies that video controls should be displayed (such as a play/pause button etc).',
             false,
-            'controls'
+            'controls',
         );
 
         $this->registerArgument(
             'video',
             Video::class,
             'The video that is rendered.',
-            true
+            true,
         );
     }
 

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -61,5 +61,5 @@ $additionalColumns = [
 
 ExtensionManagementUtility::addTCAcolumns(
     'sys_file_reference',
-    $additionalColumns
+    $additionalColumns,
 );

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::addStaticFile(
     'html5mediakit',
     'Configuration/TypoScript',
-    'HTML5 Media Kit'
+    'HTML5 Media Kit',
 );

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -12,11 +12,11 @@ ExtensionUtility::registerPlugin(
     'Html5mediakit',
     'mediarenderer',
     'LLL:EXT:html5mediakit/Resources/Private/Language/locallang_db.xlf:tt_content.CType.I.html5mediakit_mediarenderer',
-    'mimetypes-x-content-multimedia'
+    'mimetypes-x-content-multimedia',
 );
 
-$GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['html5mediakit_mediarenderer'] =
-    'mimetypes-x-content-multimedia';
+$GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['html5mediakit_mediarenderer']
+    = 'mimetypes-x-content-multimedia';
 
 $columns = [
     'tx_html5mediakit_media' => [

--- a/Configuration/TCA/tx_html5mediakit_domain_model_media.php
+++ b/Configuration/TCA/tx_html5mediakit_domain_model_media.php
@@ -163,7 +163,7 @@ return [
                 [
                     'ogg',
                     'ogx',
-                ]
+                ],
             ),
         ],
         'h264' => [
@@ -180,7 +180,7 @@ return [
             'label' => $languagePrefixColumn . 'poster',
             'config' => $buildFileFieldConfig(
                 allowedFileTypes: 'common-image-types',
-                createNewRelationLinkTitle: $lllAddImageFileReference
+                createNewRelationLinkTitle: $lllAddImageFileReference,
             ),
         ],
         'sys_language_uid' => [

--- a/Tests/Acceptance/Backend/ContentCreationCest.php
+++ b/Tests/Acceptance/Backend/ContentCreationCest.php
@@ -28,7 +28,7 @@ class ContentCreationCest
         $modalDialog->canSeeDialog();
         $I->executeJS(
             'document.querySelector(\'typo3-backend-new-content-element-wizard\').shadowRoot'
-            . '.querySelector(\'button[data-identifier="common_html5mediakit_mediarenderer"]\').click()'
+            . '.querySelector(\'button[data-identifier="common_html5mediakit_mediarenderer"]\').click()',
         );
 
         $I->switchToContentFrame();
@@ -69,7 +69,7 @@ class ContentCreationCest
     {
         return sprintf(
             'div[role="tabpanel"] > ul.nav-tabs > li.t3js-tabmenu-item:nth-child(%d) > a',
-            $tabNumber
+            $tabNumber,
         );
     }
 }

--- a/Tests/Acceptance/Support/Extension/BackendHtml5mediakitEnvironment.php
+++ b/Tests/Acceptance/Support/Extension/BackendHtml5mediakitEnvironment.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Sto\Html5mediakit\Tests\Acceptance\Support\Extension;
 
 use Codeception\Event\SuiteEvent;
-use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
 use RuntimeException;
+use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
 
 class BackendHtml5mediakitEnvironment extends BackendEnvironment
 {

--- a/Tests/Functional/Controller/MediaController/AbstractMediaControllerTestCase.php
+++ b/Tests/Functional/Controller/MediaController/AbstractMediaControllerTestCase.php
@@ -55,7 +55,7 @@ abstract class AbstractMediaControllerTestCase extends FunctionalTestCase
             [
                 'setup' => $this->typoscriptSetupFilesDefault,
                 'constants' => $this->typoscriptConstantFiles,
-            ]
+            ],
         );
         $this->setUpFrontendSite(1);
 

--- a/Tests/Functional/Controller/MediaController/VideoTest.php
+++ b/Tests/Functional/Controller/MediaController/VideoTest.php
@@ -67,12 +67,12 @@ class VideoTest extends AbstractMediaControllerTestCase
     {
         self::assertStringContainsString(
             'Testcaption',
-            $this->getSingleElement($metaDataElement, '.tx-html5mediakit-media-caption')->text()
+            $this->getSingleElement($metaDataElement, '.tx-html5mediakit-media-caption')->text(),
         );
 
         self::assertStringContainsString(
             'Testdescription',
-            $this->getSingleElement($metaDataElement, '.tx-html5mediakit-media-description')->text()
+            $this->getSingleElement($metaDataElement, '.tx-html5mediakit-media-description')->text(),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"squizlabs/php_codesniffer": "^3.7",
 		"symfony/dom-crawler": "^6.3",
 		"typo3/cms-filelist": "*",
-		"typo3/cms-fluid-styled-content": "*"
+		"typo3/cms-fluid-styled-content": "*",
+		"typo3/cms-install": "*"
 	},
 	"replace": {
 		"typo3-ter/html5mediakit": "self.version"

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -23,13 +23,13 @@ CREATE TABLE tx_html5mediakit_domain_model_media (
 	parent_table varchar(255) DEFAULT '' NOT NULL,
 
 	type varchar(100) DEFAULT '' NOT NULL,
-	tracks tinyint(3) unsigned DEFAULT '0' NOT NULL,
+	tracks int unsigned DEFAULT '0' NOT NULL,
 	caption varchar(255) DEFAULT '' NOT NULL,
 	description text NOT NULL,
-	mp3 tinyint(3) unsigned DEFAULT '0' NOT NULL,
-	ogg tinyint(3) unsigned DEFAULT '0' NOT NULL,
-	h264 tinyint(3) unsigned DEFAULT '0' NOT NULL,
-	ogv tinyint(3) unsigned DEFAULT '0' NOT NULL,
-	poster tinyint(3) unsigned DEFAULT '0' NOT NULL,
-	web_m tinyint(3) unsigned DEFAULT '0' NOT NULL
+	mp3 int unsigned DEFAULT '0' NOT NULL,
+	ogg int unsigned DEFAULT '0' NOT NULL,
+	h264 int unsigned DEFAULT '0' NOT NULL,
+	ogv int unsigned DEFAULT '0' NOT NULL,
+	poster int unsigned DEFAULT '0' NOT NULL,
+	web_m int unsigned DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
When elements are copied TYPO3's DataHandler first writes the UID of the related element into the field.

This will cause errors when the UIDs get too large to fit into the TINYURL fields.

To fix this the fields are changed to UNSIGNED INT fields.